### PR TITLE
Add a development server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # bercerita
+
+## Development Server
+
+There is a Python-based development server that can redirect routes such as `/about`
+to `about.html`. To use it, ensure [Python 3](https://www.python.org/) is installed
+on your computer.
+
+The server will run on port 8080 by default, but this can be overridden with the
+`PORT` environment variable. If port 8080 is not available, the server will iterate
+until an available port is found.
+
+### Usage
+
+Run the following command in a terminal in the repository's directory.
+
+```bash
+python3 server.py
+```

--- a/server.py
+++ b/server.py
@@ -1,0 +1,70 @@
+"""
+HTTP Basic Server
+Contributors:
+    :: H. Kamran [@hkamran80] (author)
+License: MIT
+"""
+
+import http.server
+import os
+import socketserver
+
+
+class RequestHandler(http.server.SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        # Map .html, .css, .js, and image files automatically
+        if (
+            path.endswith(".html")
+            or path.endswith(".css")
+            or path.endswith(".js")
+            or path.endswith(".jpg")
+            or path.endswith(".jpeg")
+            or path.endswith(".png")
+            or path.endswith(".gif")
+        ):
+            return super().translate_path(path)
+
+        if path == "/":
+            return "index.html"
+
+        # If the URL doesn't have an extension, try to serve .html first
+        html_path = super().translate_path(path + ".html")
+        if os.path.isfile(html_path):
+            return html_path
+
+        # If no .html file exists, serve the requested path with a .html extension
+        return super().translate_path(path + ".html")
+
+
+def serve(port: int) -> bool:
+    # Create the server with the custom handler
+    with socketserver.TCPServer(("", port), RequestHandler) as httpd:
+        print(f"Serving at http://localhost:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            httpd.server_close()
+            return False
+
+    return False
+
+
+if __name__ == "__main__":
+    # Set the server port and directory
+    port = os.getenv("PORT", 8080)
+    directory = os.getcwd()
+    os.chdir(directory)
+
+    # Automatically generate URL mappings for HTML files in the current directory
+    url_mappings = {}
+    for filename in os.listdir(directory):
+        if filename != "index.html" and filename.endswith(".html"):
+            url_mappings["/" + os.path.splitext(filename)[0]] = filename
+
+    serve_status = True
+    while serve_status:
+        try:
+            serve_status = serve(port)
+        except OSError as error:
+            if error.errno == 98:  # Address already in use
+                port += 1


### PR DESCRIPTION
This PR adds a Python-based development server that can redirect `/` to `index.html`, `/about` to `about.html`, and so on, so forth.